### PR TITLE
Make everything compile now

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val root = (project in file("."))
     name := "quickstart",
     version := "0.0.1-SNAPSHOT",
     scalaVersion := "2.12.6",
-    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0-M1"),
+    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0-M2"),
     libraryDependencies ++= Seq(
       "org.http4s"      %% "http4s-blaze-server" % Http4sVersion,
       "org.http4s"      %% "http4s-blaze-client" % Http4sVersion,

--- a/src/main/scala/com/example/quickstart/Server.scala
+++ b/src/main/scala/com/example/quickstart/Server.scala
@@ -15,8 +15,8 @@ object Server {
   def stream[F[_]: ConcurrentEffect](implicit T: Timer[F], C: ContextShift[F]): Stream[F, ExitCode] =
     for {
       client <- BlazeClientBuilder[F](global).stream
-      implicit0(helloWorldAlg) = HelloWorldAlg.impl[F]
-      implicit0(jokeAlg) <- Stream.pure(JokeAlg.impl[F](client)).covary[F]
+      implicit0(helloWorldAlg: HelloWorldAlg[F]) = HelloWorldAlg.impl[F]
+      implicit0(jokeAlg: JokeAlg[F]) <- Stream(JokeAlg.impl[F](client)).covary[F]
 
       // Combine Service Routes into an HttpApp
       // Can also be done via a Router if you


### PR DESCRIPTION
I've published the updated version - it now requires type to be specified, as a smart hack of me using singleton types was limiting in some cases. A number of extra edge cases were caught and fixed along the way.

Also, in latest fs2 there's no `Stream.pure`, so it was using one from `cats.implicits` - the one that lets you write `42.pure[IO]`, and it caused a lot of confusion 😆 